### PR TITLE
fix: add error type for the case of 'no migration found for version ...'

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -55,6 +55,15 @@ func (e ErrDirty) Error() string {
 	return fmt.Sprintf("Dirty database version %v. Fix and force version.", e.Version)
 }
 
+type ErrVersionNotFound struct {
+	Version uint
+	err     error
+}
+
+func (e ErrVersionNotFound) Error() string {
+	return fmt.Sprintf("no migration found for version %v: %v", e.Version, e.err)
+}
+
 type Migrate struct {
 	sourceName   string
 	sourceDrv    source.Driver
@@ -806,7 +815,7 @@ func (m *Migrate) versionExists(version uint) (result error) {
 		return err
 	}
 
-	err = fmt.Errorf("no migration found for version %d: %w", version, err)
+	err = ErrVersionNotFound{version, err}
 	m.logErr(err)
 	return err
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -905,6 +905,32 @@ func TestDownDirty(t *testing.T) {
 	}
 }
 
+func TestUpOutdatedSource(t *testing.T) {
+	m, _ := New("stub://", "stub://")
+	dbDrv := m.databaseDrv.(*dStub.Stub)
+	if err := dbDrv.SetVersion(10, false); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Up()
+	if _, ok := err.(ErrVersionNotFound); !ok {
+		t.Fatalf("expected ErrVersionNotFound, got %v", err)
+	}
+}
+
+func TestDownOutdatedSource(t *testing.T) {
+	m, _ := New("stub://", "stub://")
+	dbDrv := m.databaseDrv.(*dStub.Stub)
+	if err := dbDrv.SetVersion(10, false); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Down()
+	if _, ok := err.(ErrVersionNotFound); !ok {
+		t.Fatalf("expected ErrVersionNotFound, got %v", err)
+	}
+}
+
 func TestDrop(t *testing.T) {
 	m, _ := New("stub://", "stub://")
 	m.sourceDrv.(*sStub.Stub).Migrations = sourceStubMigrations


### PR DESCRIPTION
The main reason for this change is ability to identify and gracefully handle rollbacks.

For example a service executes `migrate` during its deployment as init job and the source of its migration SQLs is packaged inside docker image.
Now imagine that version 2.0 of that service bumps DB schema to version 2. An attempt to deploy previous version of the service (let's say 1.9) would fail during migration step due to the absence of 2_*up/down.sql without a handler for that condition.

The handler in cmd/migrate would look like:
```
	if err = migrator.Up(); err != nil {
		if errors.Is(err, migrate.ErrNoChange) {
			log.Info("Schema is up to date")
		else if errors.Is(err, migrate.ErrVersionNotFound) {
			log.Info("Schema is higher version than the source")
		} else {
			log.Errorf("Failed to exectue migration: %v", err)
		}
	} else {
		log.Info("Schema migration completed")
	}
```