### PR TITLE
fix: remove fmt.Printf, overly verbose

### DIFF
--- a/database/multistmt/parse.go
+++ b/database/multistmt/parse.go
@@ -73,8 +73,6 @@ func Parse(reader io.Reader, delimiter []byte, maxMigrationSize int, replacement
 						discard = true
 					}
 				}
-				// output the content, for logging
-				fmt.Printf("%c", buf[i])
 				switch ch := buf[i]; ch {
 				case '$':
 					// look around is there another $?


### PR DESCRIPTION
Just removing fmt.Printf(), lower the volume of output from multistmt parse
[QSS-1321]

[QSS-1321]: https://outreach-io.atlassian.net/browse/QSS-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ