### PR TITLE
fix: parsing buffer edge case at end of buffer

### DIFF
--- a/database/multistmt/parse.go
+++ b/database/multistmt/parse.go
@@ -47,13 +47,22 @@ func Parse(reader io.Reader, _ []byte, _ int, replacementStatement string, h Han
 	tmp := make([]byte, 0, 10)
 	a := 0
 	for err == nil {
+		// this is non-performant but very clear that the buf variable is wiped out
+		//completely between loop iterations
 		buf = make([]byte, ParseBufSize)
 		n, err := reader.Read(buf)
 		trace("tmp(2): '%s', buf: %s, discard: %v\n", tmp, buf, discard)
+		// tmp is the carry-over buffer,
+		//if the previous loop iteration had two few characters to make comparisions,
+		//tmp will have the characters at the point the loop iteration was abandoned(
+		//break'd out of)
 		if len(tmp) > 0 {
 			trace("copying '%s' to buf\n", tmp)
 			buf = append(tmp, buf[:n]...)
 			trace("buf: %s\n", buf)
+			// n needs to include the length of tmp since it was copied into n,
+			// but n originally only held the number of chars read from the
+			// reader.Read(buf) call.
 			n = n + len(tmp)
 			tmp = tmp[:0]
 

--- a/database/multistmt/parse.go
+++ b/database/multistmt/parse.go
@@ -2,10 +2,10 @@
 package multistmt
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/pkg/errors"
 	"io"
-	"strings"
 )
 
 // ParseBufSize is the buffer size for the multi-statement reader
@@ -130,9 +130,8 @@ func Parse(reader io.Reader, _ []byte, _ int, replacementStatement string, h Han
 						stmt := make([]byte, len(accum))
 						copy(stmt, accum)
 						if replacementStatement != "" {
-							stmt := strings.ReplaceAll(string(stmt), "<SCHEMA_NAME>",
-								replacementStatement)
-							stmt = []byte(stmt)
+							stmt = bytes.ReplaceAll(stmt, []byte("<SCHEMA_NAME>"),
+								[]byte(replacementStatement))
 						}
 
 						// fully formed statement(stmt), exec the statement

--- a/database/multistmt/parse.go
+++ b/database/multistmt/parse.go
@@ -53,7 +53,7 @@ func Parse(reader io.Reader, _ []byte, _ int, replacementStatement string, h Han
 		n, err := reader.Read(buf)
 		trace("tmp(2): '%s', buf: %s, discard: %v\n", tmp, buf, discard)
 		// tmp is the carry-over buffer,
-		//if the previous loop iteration had two few characters to make comparisions,
+		//if the previous loop iteration had too few characters to make comparisons,
 		//tmp will have the characters at the point the loop iteration was abandoned(
 		//break'd out of)
 		if len(tmp) > 0 {

--- a/database/multistmt/parse_test.go
+++ b/database/multistmt/parse_test.go
@@ -25,33 +25,77 @@ func TestParse(t *testing.T) {
 	$$ LANGUAGE plpgsql;`
 
 	testCases := []struct {
-		name        string
-		multiStmt   string
-		delimiter   string
-		expected    []string
-		expectedErr error
+		name         string
+		multiStmt    string
+		delimiter    string
+		expected     []string
+		expectedErr  error
+		parseBufSize int
 	}{
-		//// these tests are changed from their original, why would we expect to add a missing delimiter?
-		{name: "single statement, no delimiter", multiStmt: "single statement, no delimiter", delimiter: ";",
-			expected: []string{}, expectedErr: nil},
-		{name: "single statement, one delimiter", multiStmt: "single statement, one delimiter;", delimiter: ";",
-			expected: []string{"single statement, one delimiter;"}, expectedErr: nil},
-		
-		{name: "two statements, no trailing delimiter", multiStmt: "statement one; statement two", delimiter: ";",
-			expected: []string{"statement one;"}, expectedErr: nil},
-		{name: "two statements, with trailing delimiter", multiStmt: "statement one; statement two;", delimiter: ";",
-			expected: []string{"statement one;", " statement two;"}, expectedErr: nil},
-		{name: "multi line plpgsql body", multiStmt: plpgsqlBody, delimiter: "$$.*;",
-			expected: []string{plpgsqlBody}, expectedErr: nil},
+		// these tests are changed from their original, why would we expect to add a missing delimiter?
+		{name: "single statement, no delimiter",
+			multiStmt:   "single statement, no delimiter",
+			delimiter:   ";",
+			expected:    []string{},
+			expectedErr: nil},
+		{name: "single statement, one delimiter",
+			multiStmt:   "single statement, one delimiter;",
+			delimiter:   ";",
+			expected:    []string{"single statement, one delimiter;"},
+			expectedErr: nil},
+		{name: "two statements, no trailing delimiter",
+			multiStmt:   "statement one; statement two",
+			delimiter:   ";",
+			expected:    []string{"statement one;"},
+			expectedErr: nil},
+		{name: "two statements, with trailing delimiter",
+			multiStmt:   "statement one; statement two;",
+			delimiter:   ";",
+			expected:    []string{"statement one;", " statement two;"},
+			expectedErr: nil},
+		{name: "multi line plpgsql body",
+			multiStmt:   plpgsqlBody,
+			delimiter:   "$$.*;",
+			expected:    []string{plpgsqlBody},
+			expectedErr: nil},
+		// this test case has the following characteristics:
+		// 1. there is a comment at the very last character/index of the read
+		//    buffer when the buffer size is 5
+		// 2. there are two dashes(0, 1), a new line(2) followed by a tab(3),
+		//    then a dash(4)(this dash is at the end of the buffer and must be
+		//    carreied over to the next loop iteration (
+		//   two characters in the buffer needed to check for comment.
+		{name: "pg_dump output,comments",
+			multiStmt: `--
+	-- PostgreSQL database dump
+--
+CREATE EXTENSION IF NOT EXISTS citext SCHEMA public;
+`,
+			delimiter:    ";",
+			parseBufSize: 5,
+			expected: []string{"\tCREATE EXTENSION IF NOT EXISTS citext SCHEMA" +
+				" public;"},
+			expectedErr: nil},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			parseBufSize := multistmt.ParseBufSize
+			defer func() {
+				multistmt.ParseBufSize = parseBufSize
+			}()
+			if tc.parseBufSize > 0 {
+				multistmt.ParseBufSize = tc.parseBufSize
+			}
+
+			t.Logf("multiStmt: %s\n", tc.multiStmt)
 			stmts := make([]string, 0, len(tc.expected))
-			err := multistmt.Parse(strings.NewReader(tc.multiStmt), []byte(tc.delimiter), maxMigrationSize, "", func(b []byte) bool {
-				stmts = append(stmts, string(b))
-				return true
-			})
+			err := multistmt.Parse(strings.NewReader(tc.multiStmt),
+				[]byte(tc.delimiter),
+				maxMigrationSize, "", func(b []byte) error {
+					stmts = append(stmts, string(b))
+					return nil
+				})
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, tc.expected, stmts)
 		})
@@ -64,10 +108,11 @@ func TestParseDiscontinue(t *testing.T) {
 	expected := []string{"statement one;"}
 
 	stmts := make([]string, 0, len(expected))
-	err := multistmt.Parse(strings.NewReader(multiStmt), []byte(delimiter), maxMigrationSize, "", func(b []byte) bool {
-		stmts = append(stmts, string(b))
-		return false
-	})
+	err := multistmt.Parse(strings.NewReader(multiStmt), []byte(delimiter),
+		maxMigrationSize, "", func(b []byte) error {
+			stmts = append(stmts, string(b))
+			return nil
+		})
 	assert.Nil(t, err)
 	assert.Equal(t, expected, stmts)
 }


### PR DESCRIPTION
When at the edge of the buffered reader(the byte buffer used for parsing), handle when there are not enough characters to check for comment conditions.

Adds a new test case for multi-line statements with comments at the edge of th read buffer.

Adds new tracing function to keep tracing in code.

Makes the parse buffer size configurable by a variable, used only for tests.
