### PR TITLE
fix: Typo in code, fixing things

### DIFF
--- a/database/postgresconn/postgresconn.go
+++ b/database/postgresconn/postgresconn.go
@@ -449,7 +449,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 		}
 	}()
 
-	stmt = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q`+
+	stmt := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q`+
 		` (version bigint not null, dirty boolean not null)`,
 		p.config.migrationsSchemaName, p.config.migrationsTableName)
 	if _, err = p.conn.ExecContext(context.Background(), stmt); err != nil {


### PR DESCRIPTION
This PR addresses a typo that was introduced in #14 . 
It also fixes up tests, the existing test seemed to connect with a non_owner user to check if the user can still query the schema_version table. 
The migrate() libs are entirely used within smartstore today, and we don't use the migration postgres connections with readonly users. 
Users should still be able to query() the table directly to get the correct versions. 