### PR TITLE
fix: put nulls last, they are the oldest

### DIFF
--- a/database/postgresconn/postgresconn.go
+++ b/database/postgresconn/postgresconn.go
@@ -342,7 +342,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 
 func (p *Postgres) Version() (*database.Version, error) {
 	stmt := fmt.Sprintf(`SELECT version, dirty, info, current_schema() FROM %q.%q`+
-		` ORDER BY created_at desc LIMIT 1`,
+		` ORDER BY created_at desc nulls last LIMIT 1`,
 		p.config.migrationsSchemaName, p.config.migrationsTableName)
 
 	var (


### PR DESCRIPTION
ensure nulls as last when ordering created_at, this makes sure that we don't select null created_at records before actual created_records(nulls are ordering before values and we don't want that).