### PR TITLE
feat: add transactions to migrations

### DIFF
--- a/database/driver.go
+++ b/database/driver.go
@@ -93,6 +93,15 @@ type Driver interface {
 	// Note that this is a breaking action, a new call to Open() is necessary to
 	// ensure subsequent calls work as expected.
 	Drop() error
+
+	// Begin driver to begin transaction here
+	Begin() error
+
+	// Commit driver to commit transaction here
+	Commit() error
+
+	// Rollback driver to rollback here
+	Rollback() error
 }
 
 // Open returns a new driver instance.

--- a/database/driver_test.go
+++ b/database/driver_test.go
@@ -56,6 +56,18 @@ func (m *mockDriver) SetFailed(_ int, _ error) error {
 	return nil
 }
 
+func (m *mockDriver) Begin() error {
+	return nil
+}
+
+func (m *mockDriver) Commit() error {
+	return nil
+}
+
+func (m *mockDriver) Rollback() error {
+	return nil
+}
+
 func TestRegisterTwice(t *testing.T) {
 	Register("mock", &mockDriver{})
 

--- a/database/postgresconn/examples/migrations/1285849751_add_index_on_user_emails.up.sql
+++ b/database/postgresconn/examples/migrations/1285849751_add_index_on_user_emails.up.sql
@@ -1,3 +1,3 @@
-CREATE UNIQUE INDEX CONCURRENTLY users_email_index ON users (email);
+CREATE UNIQUE INDEX users_email_index ON users (email);
 
 -- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sed interdum velit, tristique iaculis justo. Pellentesque ut porttitor dolor. Donec sit amet pharetra elit. Cras vel ligula ex. Phasellus posuere.

--- a/database/stub/stub.go
+++ b/database/stub/stub.go
@@ -1,10 +1,11 @@
 package stub
 
 import (
-	"go.uber.org/atomic"
 	"io"
 	"io/ioutil"
 	"reflect"
+
+	"go.uber.org/atomic"
 
 	"github.com/getoutreach/migrate/v4/database"
 )
@@ -98,4 +99,16 @@ func (s *Stub) SetFailed(version int, err error) error {
 
 func (s *Stub) EqualSequence(seq []string) bool {
 	return reflect.DeepEqual(seq, s.MigrationSequence)
+}
+
+func (m *Stub) Begin() error {
+	return nil
+}
+
+func (m *Stub) Commit() error {
+	return nil
+}
+
+func (m *Stub) Rollback() error {
+	return nil
 }


### PR DESCRIPTION
Adds transactions to migrations, include set version.

Before this commit, only SetVersion() ran in a database transaction. Now, after this change, both SetVersion() and each file run in their own transaction.