### PR TITLE
fix: remove multi line statement parsing

### DIFF
--- a/database/postgresconn/postgresconn_test.go
+++ b/database/postgresconn/postgresconn_test.go
@@ -283,7 +283,9 @@ func TestErrorParsing(t *testing.T) {
 			}
 		}()
 
-		wantErr := `migration failed: syntax error at or near "TABLEE" (column 9) in line 1:  CREATE TABLEE bar (bar text); (details: pq: syntax error at or near "TABLEE")`
+		// Parser no longer does line or statement parsing.
+		//
+		wantErr := `migration failed: syntax error at or near "TABLEE" (column 37) in line 1: CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text); (details: pq: syntax error at or near "TABLEE")`
 		if err := d.Run(strings.NewReader(`CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);`)); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {

--- a/database/postgresconn/postgresconn_test.go
+++ b/database/postgresconn/postgresconn_test.go
@@ -294,6 +294,31 @@ func TestErrorParsing(t *testing.T) {
 	})
 }
 
+func TestEmbeddedComment(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		d, err := p.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := d.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		if err := d.Run(strings.NewReader(`create table consumers(skip boolean, skip_reason text, name text); UPDATE consumers SET skip = true, skip_reason = 'https://outreach-hq.slack.com/archives/C03TX2QNHTQ/p1686116838617179 -- settings org life events are unneeded' WHERE name = 'settings'`)); err != nil {
+			t.Fatalf("expected no error but got %v", err)
+		}
+	})
+}
+
 func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()


### PR DESCRIPTION
This PR re-introduces (to master) the removal of multi-line statement parsing.

Smartstore used this branch for a long time, go.mod for services were updated to this commit, but this was never merged to master. This PR fixes that by adding the changes that are currently in use by smartstore (by referencing this branch commit). 

Many repos go.mod reference this commit:
 `github.com/getoutreach/migrate/v4 v4.15.2-0.20230830172021-198160d0208e`

which is this branch(well one of the commits on this branch). 

https://github.com/search?q=org%3Agetoutreach+path%3Ago.mod+migrate&type=code

